### PR TITLE
Update ethereum.json

### DIFF
--- a/src/tokens/ethereum.json
+++ b/src/tokens/ethereum.json
@@ -78,5 +78,13 @@
         "decimals": 18,
         "chainId": 1,
         "logoURI": "https://raw.githubusercontent.com/sameepsi/quickswap-interface/master/public/favicon1.png"
-      }
+      },
+    {
+  "chainId": 1,
+  "address": "0x4e072E18387FDc4C5768b0a99d5FABc5a28F7296",
+  "symbol": "XTH",
+  "name": "XCOIN",
+  "decimals": 18,
+  "logoURI": "https://xcoineth.com/logo.png"
+}
 ]


### PR DESCRIPTION
Add XCOIN (XTH) token to QuickSwap default token list

- Contract: 0x4e072E18387FDc4C5768b0a99d5FABc5a28F7296
- Symbol: XTH
- Name: XCOIN
- Decimals: 18
- Logo: https://xcoineth.com/logo.png

XCOIN is a verified ERC-20 token with active trading on multiple DEXs including KyberSwap. The token has a growing community and is already listed on DexTools, CoinPaprika, and GeckoTerminal.

This submission adds XCOIN to the Ethereum mainnet token list to improve user experience and token recognition on QuickSwap.